### PR TITLE
anitubeinua: виправлено витяг посилань/плейлистів (UA/Referer, fallback dle_login_hash), v16

### DIFF
--- a/AnitubeinuaProvider/build.gradle.kts
+++ b/AnitubeinuaProvider/build.gradle.kts
@@ -1,5 +1,5 @@
 // use an integer for version numbers
-version = 15
+version = 16
 
 dependencies {
     testImplementation(libs.junit)


### PR DESCRIPTION
## Що змінено
- Додано стабільний `USER_AGENT` і `Referer` до всіх запитів: `getMainPage`, `search`, `load`, а також до non-AJAX/AJAX шляхів.
- Додано fallback для `dle_login_hash`: якщо порожній - отримуємо його зі сторінки тайтлу за ID і парсимо зі скрипта.
- Для AJAX запиту `playlists.php` додано `User-Agent` разом з `X-Requested-With`.
- Підвищено версію модуля: **AnitubeinuaProvider** version 15 → 16.

## Чому це потрібно
- Без коректних заголовків сайт віддавав неповні/заблоковані відповіді.
- Відсутній `dle_login_hash` ламав завантаження плейлисту (порожні джерела/епізоди).

## Результат/перевірка
- Головна і пошук працюють; сторінка тайтлу парситься.
- Джерела/епізоди завантажуються в обох режимах (AJAX і non-AJAX), `RalodePlayer.init` обробляється коректно.

## Зона впливу
- Лише **AnitubeinuaProvider**; breaking changes відсутні.

## Змінені файли
- `AnitubeinuaProvider/build.gradle.kts` - версія 15 → 16
- `AnitubeinuaProvider/src/main/kotlin/com/lagradost/AnitubeinuaProvider.kt` - заголовки, fallback `dle_login_hash`, дрібні правки